### PR TITLE
Maintenance Via DNS Name

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,23 +19,41 @@ I recommend running this on the local node as follows:
       roles:
          - { role: asagage.orion-node-manage }
       tasks:
-        - name: Unmanage node
+        - name: Unmanage node via IP Address
           local_action:
             module: orion_node_manage
             ip_address: hostvars[inventory_hostname]['ansible_default_ipv4']['address']
             state: unmanaged
-            username: {{ sw_username }}
-            password: {{ sw_password }}
-            hostname: {{ sw_hostname }}
+            username: "{{ sw_username }}"
+            password: "{{ sw_password }}"
+            hostname: "{{ sw_hostname }}"
 
-        - name: Remanage node
+        - name: Unmanage node via DNS Name
+          local_action:
+            module: orion_node_manage
+            dns_name: "{{inventory_hostname}}"
+            state: unmanaged
+            username: "{{ sw_username }}"
+            password: "{{ sw_password }}"
+            hostname: "{{ sw_hostname }}"
+
+        - name: Remanage node via IP Address
           local_action:
             module: orion_node_manage
             ip_address: hostvars[inventory_hostname]['ansible_default_ipv4']['address']
             state: managed
-            username: {{ sw_username }}
-            password: {{ sw_password }}
-            hostname: {{ sw_hostname }}
+            username: "{{ sw_username }}"
+            password: "{{ sw_password }}"
+            hostname: "{{ sw_hostname }}"
+
+        - name: Remanage node via DNS Name
+          local_action:
+            module: orion_node_manage
+            dns_name: "{{inventory_hostname}}"
+            state: managed
+            username: "{{ sw_username }}"
+            password: "{{ sw_password }}"
+            hostname: "{{ sw_hostname }}"
 
 License
 -------

--- a/README.md
+++ b/README.md
@@ -15,9 +15,14 @@ Example Playbook
 
 I recommend running this on the local node as follows:
 
-    - hosts: all
+    - name: Setup Local Solarwinds
+      hosts: localhost
+      gather_facts: no
       roles:
-         - { role: asagage.orion-node-manage }
+          - { role: asagage.orion-node-manage }
+
+    - name: Solarwinds Manage Nodes
+      hosts: all
       tasks:
         - name: Unmanage node via IP Address
           local_action:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,6 +8,5 @@
   with_items:
     - orionsdk
     - requests
-#    - traceback
     - datetime
     - pandas


### PR DESCRIPTION
I wanted to be able to put a node into maintenance via DNS as that allows me to use:

dns_name: "{{inventory_hostname}}"

I added the function to be able to do so, and added a bit to readme showing the different methods.

I cancelled the other, as I forgot to push the readme update.