### PR TITLE
switching from requests.urllib3 to urllib3

### DIFF
--- a/library/orion_node_manage.py
+++ b/library/orion_node_manage.py
@@ -115,10 +115,11 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 
 import requests
+import urllib3
 from datetime import datetime, timedelta
 
 __SWIS__ = None
-requests.packages.urllib3.disable_warnings()
+urllib3.disable_warnings()
 
 def main():
     global __SWIS__

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,3 +10,4 @@
     - requests
     - datetime
     - pandas
+    - urllib3


### PR DESCRIPTION
On the versions of requests and urllib3 I have on the CentOS box I use as a controller, I had to switch to this method of disabling the urllib3 warnings. It also worked in a Xenial container I used to test.